### PR TITLE
Improve preprocessor handling

### DIFF
--- a/glsld-core/include/Compiler/PPCallback.h
+++ b/glsld-core/include/Compiler/PPCallback.h
@@ -9,6 +9,9 @@ namespace glsld
     class PPCallback
     {
     public:
+        PPCallback()          = default;
+        virtual ~PPCallback() = default;
+
         // Called when a `#version XXX` directive is encountered
         virtual auto OnVersionDirective(FileID file, TextRange range, GlslVersion version, GlslProfile profile) -> void
         {
@@ -17,6 +20,11 @@ namespace glsld
         // Called when a `#extension EXTENSION : behavior` directive is encountered
         virtual auto OnExtensionDirective(FileID file, TextRange range, ExtensionId extension,
                                           ExtensionBehavior behavior) -> void
+        {
+        }
+
+        // Called when an unknown `#pragma XXX` directive is encountered
+        virtual auto OnUnknownPragmaDirective(ArrayView<PPToken> argTokens) -> void
         {
         }
 

--- a/glsld-core/include/Compiler/Preprocessor.h
+++ b/glsld-core/include/Compiler/Preprocessor.h
@@ -251,6 +251,10 @@ namespace glsld
         // This stack stores all information about the conditional directives.
         std::vector<PPConditionalInfo> conditionalStack = {};
 
+        AtomString atomBuiltinLineMacro    = {};
+        AtomString atomBuiltinFileMacro    = {};
+        AtomString atomBuiltinVersionMacro = {};
+
     public:
         PreprocessStateMachine(CompilerInvocationState& compiler, TokenStream& outputStream, TranslationUnitID tuId,
                                PPCallback* callback, std::optional<TextRange> includeExpansionRange,
@@ -260,6 +264,9 @@ namespace glsld
               outputStream(outputStream), tuId(tuId), callback(callback), macroExpansionProcessor(*this),
               includeExpansionRange(includeExpansionRange), includeDepth(includeDepth)
         {
+            atomBuiltinLineMacro    = atomTable.GetAtom("__LINE__");
+            atomBuiltinFileMacro    = atomTable.GetAtom("__FILE__");
+            atomBuiltinVersionMacro = atomTable.GetAtom("__VERSION__");
         }
 
         auto GetState() const noexcept -> PreprocessorState
@@ -405,6 +412,7 @@ namespace glsld
         auto HandleEndifDirective(PPTokenScanner& scanner) -> void;
         auto HandleExtensionDirective(PPTokenScanner& scanner) -> void;
         auto HandleVersionDirective(PPTokenScanner& scanner) -> void;
+        auto HandlePragmaDirective(PPTokenScanner& scanner) -> void;
         auto HandleLineDirective(PPTokenScanner& scanner) -> void;
 
         // Consumes all tokens and returns the result of the preprocessing expression.

--- a/glsld-test/include/CompilerTestFixture.h
+++ b/glsld-test/include/CompilerTestFixture.h
@@ -5,6 +5,7 @@
 
 #include "Basic/StringView.h"
 #include "Compiler/CompilerInvocation.h"
+#include "Compiler/PPCallback.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
@@ -109,12 +110,13 @@ namespace glsld
             return matcherTemplate(matcher);
         }
 
-        auto Compile(StringView sourceText, CompileMode compileMode) const -> std::unique_ptr<CompilerResult>
+        auto Compile(StringView sourceText, CompileMode compileMode, PPCallback* ppCallback = nullptr) const
+            -> std::unique_ptr<CompilerResult>
         {
             auto compiler = std::make_unique<CompilerInvocation>();
             compiler->SetNoStdlib(true);
             compiler->SetMainFileFromBuffer(sourceText);
-            return compiler->CompileMainFile(nullptr, compileMode);
+            return compiler->CompileMainFile(ppCallback, compileMode);
         }
 
 #pragma region Token Matchers


### PR DESCRIPTION
- Fix a bug where PPCallback doesn't define a virtual dtor
- Add basic support for handling `#pragma` directives in the preprocessor
- Implement builtin __LINE__, __FILE__ and __VERSION__