### PR TITLE
Allow binary operator of ConstValue to broadcast scalar and expand test coverage

### DIFF
--- a/glsld-core/include/Language/ConstValue.h
+++ b/glsld-core/include/Language/ConstValue.h
@@ -11,6 +11,47 @@
 
 namespace glsld
 {
+    template <typename T>
+    inline constexpr auto GetScalarKindFromCppType() -> ScalarKind
+    {
+        if constexpr (std::is_same_v<T, bool>) {
+            return ScalarKind::Bool;
+        }
+        else if constexpr (std::is_same_v<T, int32_t>) {
+            return ScalarKind::Int;
+        }
+        else if constexpr (std::is_same_v<T, uint32_t>) {
+            return ScalarKind::Uint;
+        }
+        else if constexpr (std::is_same_v<T, float>) {
+            return ScalarKind::Float;
+        }
+        else if constexpr (std::is_same_v<T, double>) {
+            return ScalarKind::Double;
+        }
+        else if constexpr (std::is_same_v<T, int8_t>) {
+            return ScalarKind::Int8;
+        }
+        else if constexpr (std::is_same_v<T, uint8_t>) {
+            return ScalarKind::Uint8;
+        }
+        else if constexpr (std::is_same_v<T, int16_t>) {
+            return ScalarKind::Int16;
+        }
+        else if constexpr (std::is_same_v<T, uint16_t>) {
+            return ScalarKind::Uint16;
+        }
+        else if constexpr (std::is_same_v<T, int64_t>) {
+            return ScalarKind::Int64;
+        }
+        else if constexpr (std::is_same_v<T, uint64_t>) {
+            return ScalarKind::Uint64;
+        }
+        else {
+            static_assert(false, "Unsupported C++ type for scalar kind");
+        }
+    }
+
     // Represents a compile-time constant primitive. This can be either:
     // - error
     // - scalar
@@ -38,6 +79,11 @@ namespace glsld
     public:
         ConstValue() : scalarType(0), arraySize(0), rowSize(0), colSize(0), localBuffer()
         {
+        }
+        explicit ConstValue(ScalarKind kind, int16_t rowSize, int16_t colSize) : ConstValue()
+        {
+            GLSLD_ASSERT(rowSize > 0 && colSize > 0);
+            InitializeAsBlob(kind, rowSize, colSize);
         }
         ~ConstValue()
         {
@@ -140,12 +186,33 @@ namespace glsld
         static auto ConstructVector(const ConstValue& value, ScalarKind kind, int dimSize) -> ConstValue;
 
         // Construct a matrix constant as per GLSL matrix constructor
-        static auto ConstructMatrix(const ConstValue& value, ScalarKind kind, int rolSize, int colSize) -> ConstValue;
+        static auto ConstructMatrix(const ConstValue& value, ScalarKind kind, int rowSize, int colSize) -> ConstValue;
 
         // Get a view to the constant value as a blob of bytes.
         auto GetBufferAsBlob() const -> ArrayView<std::byte>
         {
             return ArrayView<std::byte>(GetBufferPtr(), GetBufferSize());
+        }
+
+        // Get a view to the constant value as an array of the given type.
+        // The type must match the scalar kind of the constant.
+        template <typename T>
+        auto GetBufferAs() const -> ArrayView<T>
+        {
+            GLSLD_ASSERT(GetScalarKindFromCppType<T>() == GetScalarKind());
+            return ArrayView<T>(reinterpret_cast<const T*>(GetBufferPtr()), arraySize);
+        }
+
+        auto GetMutableBufferAsBlob() -> ArraySpan<std::byte>
+        {
+            return ArraySpan<std::byte>(GetBufferPtr(), GetBufferSize());
+        }
+
+        template <typename T>
+        auto GetMutableBufferAs() -> ArraySpan<T>
+        {
+            GLSLD_ASSERT(GetScalarKindFromCppType<T>() == GetScalarKind());
+            return ArraySpan<T>(reinterpret_cast<T*>(GetBufferPtr()), arraySize);
         }
 
         // Get a view to the constant element value as a blob of bytes.
@@ -163,14 +230,6 @@ namespace glsld
             }
         }
 
-        // Get a view to the constant value as an array of the given type.
-        // The type must match the scalar kind of the constant.
-        template <typename T>
-        auto GetBufferAs() const -> ArrayView<T>
-        {
-            GLSLD_ASSERT(GetScalarKindFromCppType<T>() == GetScalarKind());
-            return ArrayView<T>(reinterpret_cast<const T*>(GetBufferPtr()), arraySize);
-        }
         auto GetBoolValue() const -> bool
         {
             GLSLD_ASSERT(IsScalarBool());
@@ -281,9 +340,13 @@ namespace glsld
             return IsScalar() && GetScalarKind() == ScalarKind::Float16;
         }
 
+        // Get the size of the underlying scalar type in bytes.
         auto GetScalarSize() const noexcept -> int;
 
+        // Get a string representation of the constant value.
         auto ToString() const -> std::string;
+
+        // Create a copy of the constant value.
         auto Clone() const -> ConstValue;
 
         // Cast the underlying scalar type to the given kind while keeping the shape.
@@ -291,10 +354,14 @@ namespace glsld
         auto GetElement(int index) const -> ConstValue;
         auto GetSwizzle(SwizzleDesc swizzle) const -> ConstValue;
 
+        // Maps to `.length()` in GLSL.
+        // - For vector, this returns the number of components.
+        // - For matrix, this returns the number of columns.
+        auto Length() const -> ConstValue;
+
         auto ElemwiseNegate() const -> ConstValue;
         auto ElemwiseBitNot() const -> ConstValue;
         auto ElemwiseLogicalNot() const -> ConstValue;
-        auto Length() const -> ConstValue;
 
         auto ElemwisePlus(const ConstValue& other) const -> ConstValue;
         auto ElemwiseMinus(const ConstValue& other) const -> ConstValue;
@@ -342,268 +409,18 @@ namespace glsld
         auto ElemwiseClamp(const ConstValue& min, const ConstValue& max) const -> ConstValue;
 
     private:
-        template <typename T>
-        static constexpr auto GetScalarKindFromCppType() -> ScalarKind
-        {
-            if constexpr (std::is_same_v<T, bool>) {
-                return ScalarKind::Bool;
-            }
-            else if constexpr (std::is_same_v<T, int32_t>) {
-                return ScalarKind::Int;
-            }
-            else if constexpr (std::is_same_v<T, uint32_t>) {
-                return ScalarKind::Uint;
-            }
-            else if constexpr (std::is_same_v<T, float>) {
-                return ScalarKind::Float;
-            }
-            else if constexpr (std::is_same_v<T, double>) {
-                return ScalarKind::Double;
-            }
-            else if constexpr (std::is_same_v<T, int8_t>) {
-                return ScalarKind::Int8;
-            }
-            else if constexpr (std::is_same_v<T, uint8_t>) {
-                return ScalarKind::Uint8;
-            }
-            else if constexpr (std::is_same_v<T, int16_t>) {
-                return ScalarKind::Int16;
-            }
-            else if constexpr (std::is_same_v<T, uint16_t>) {
-                return ScalarKind::Uint16;
-            }
-            else if constexpr (std::is_same_v<T, int64_t>) {
-                return ScalarKind::Int64;
-            }
-            else if constexpr (std::is_same_v<T, uint64_t>) {
-                return ScalarKind::Uint64;
-            }
-            else {
-                static_assert(false, "Unsupported C++ type for scalar kind");
-            }
-        }
-
-        template <typename T, typename U, typename F>
-        auto ApplyElemwiseUnaryOpUnsafe(F f) const -> ConstValue
-        {
-            ConstValue result;
-
-            auto srcBuffer = GetBufferAs<T>();
-            auto dstBuffer = result.InitializeAs<U>(rowSize, colSize);
-
-            for (int i = 0; i < arraySize; ++i) {
-                dstBuffer[i] = f(srcBuffer[i]);
-            }
-            return result;
-        }
-
-        template <typename T, typename F>
-        auto ApplyElemwiseBinaryOpUnsafe(const ConstValue& other, F f) const -> ConstValue
-        {
-            ConstValue result;
-
-            auto srcBuffer1 = GetBufferAs<T>();
-            auto srcBuffer2 = other.GetBufferAs<T>();
-            auto dstBuffer  = result.InitializeAs<T>(rowSize, colSize);
-
-            for (int i = 0; i < arraySize; ++i) {
-                dstBuffer[i] = f(srcBuffer1[i], srcBuffer2[i]);
-            }
-            return result;
-        }
-
-        template <typename T, typename F>
-        auto ApplyElemwiseComparisonOpUnsafe(const ConstValue& other, F f) const -> ConstValue
-        {
-            ConstValue result;
-
-            auto srcBuffer1 = GetBufferAs<T>();
-            auto srcBuffer2 = other.GetBufferAs<T>();
-            auto dstBuffer  = result.InitializeAs<bool>(rowSize, colSize);
-
-            for (int i = 0; i < arraySize; ++i) {
-                dstBuffer[i] = f(srcBuffer1[i], srcBuffer2[i]);
-            }
-            return result;
-        }
-
-        template <typename TargetType>
-        auto ApplyElemwiseCast() const -> ConstValue
-        {
-            switch (GetScalarKind()) {
-            case ScalarKind::Bool:
-                return ApplyElemwiseUnaryOpUnsafe<bool, TargetType>([](bool x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Int:
-                return ApplyElemwiseUnaryOpUnsafe<int32_t, TargetType>(
-                    [](int32_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Uint:
-                return ApplyElemwiseUnaryOpUnsafe<uint32_t, TargetType>(
-                    [](uint32_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Float:
-                return ApplyElemwiseUnaryOpUnsafe<float, TargetType>(
-                    [](float x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Double:
-                return ApplyElemwiseUnaryOpUnsafe<double, TargetType>(
-                    [](double x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Int8:
-                return ApplyElemwiseUnaryOpUnsafe<int8_t, TargetType>(
-                    [](int8_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Int16:
-                return ApplyElemwiseUnaryOpUnsafe<int16_t, TargetType>(
-                    [](int16_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Int64:
-                return ApplyElemwiseUnaryOpUnsafe<int64_t, TargetType>(
-                    [](int64_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Uint8:
-                return ApplyElemwiseUnaryOpUnsafe<uint8_t, TargetType>(
-                    [](uint8_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Uint16:
-                return ApplyElemwiseUnaryOpUnsafe<uint16_t, TargetType>(
-                    [](uint16_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Uint64:
-                return ApplyElemwiseUnaryOpUnsafe<uint64_t, TargetType>(
-                    [](uint64_t x) { return static_cast<TargetType>(x); });
-            case ScalarKind::Float16:
-                GLSLD_NO_IMPL();
-            default:
-                return ConstValue();
-            }
-        }
-
-        template <typename F>
-        auto ApplyElemwiseUnaryOp(F f) const -> ConstValue
-        {
-#define SWITCH_CASE(CPPTYPE)                                                                                           \
-    if constexpr (requires(CPPTYPE x) { f(x); }) {                                                                     \
-        return ApplyElemwiseUnaryOpUnsafe<CPPTYPE, CPPTYPE>(f);                                                        \
-    }                                                                                                                  \
-    else {                                                                                                             \
-        return ConstValue();                                                                                           \
-    }
-            switch (static_cast<ScalarKind>(scalarType)) {
-            case ScalarKind::Bool:
-                SWITCH_CASE(bool)
-            case ScalarKind::Int:
-                SWITCH_CASE(int32_t)
-            case ScalarKind::Uint:
-                SWITCH_CASE(uint32_t)
-            case ScalarKind::Float:
-                SWITCH_CASE(float)
-            case ScalarKind::Double:
-                SWITCH_CASE(double)
-            case ScalarKind::Int8:
-                SWITCH_CASE(int8_t)
-            case ScalarKind::Int16:
-                SWITCH_CASE(int16_t)
-            case ScalarKind::Int64:
-                SWITCH_CASE(int64_t)
-            case ScalarKind::Uint8:
-                SWITCH_CASE(int8_t)
-            case ScalarKind::Uint16:
-                SWITCH_CASE(uint16_t)
-            case ScalarKind::Uint64:
-                SWITCH_CASE(uint64_t)
-            case ScalarKind::Float16:
-                GLSLD_NO_IMPL();
-            default:
-                return ConstValue();
-            }
-#undef SWITCH_CASE
-        }
-
-        template <typename F>
-        auto ApplyElemwiseBinaryOp(const ConstValue& other, F f) const -> ConstValue
-        {
-#define SWITCH_CASE(CPPTYPE)                                                                                           \
-    if constexpr (requires(CPPTYPE x) { f(x, x); }) {                                                                  \
-        return ApplyElemwiseBinaryOpUnsafe<CPPTYPE>(other, f);                                                         \
-    }                                                                                                                  \
-    else {                                                                                                             \
-        return ConstValue();                                                                                           \
-    }
-            switch (static_cast<ScalarKind>(scalarType)) {
-            case ScalarKind::Bool:
-                SWITCH_CASE(bool)
-            case ScalarKind::Int:
-                SWITCH_CASE(int32_t)
-            case ScalarKind::Uint:
-                SWITCH_CASE(uint32_t)
-            case ScalarKind::Float:
-                SWITCH_CASE(float)
-            case ScalarKind::Double:
-                SWITCH_CASE(double)
-            case ScalarKind::Int8:
-                SWITCH_CASE(int8_t)
-            case ScalarKind::Int16:
-                SWITCH_CASE(int16_t)
-            case ScalarKind::Int64:
-                SWITCH_CASE(int64_t)
-            case ScalarKind::Uint8:
-                SWITCH_CASE(int8_t)
-            case ScalarKind::Uint16:
-                SWITCH_CASE(uint16_t)
-            case ScalarKind::Uint64:
-                SWITCH_CASE(uint64_t)
-            case ScalarKind::Float16:
-                GLSLD_NO_IMPL();
-            default:
-                return ConstValue();
-            }
-#undef SWITCH_CASE
-        }
-
-        template <typename F>
-        auto ApplyElemwiseComparisonOp(const ConstValue& other, F f) const -> ConstValue
-        {
-#define SWITCH_CASE(CPPTYPE)                                                                                           \
-    if constexpr (requires(CPPTYPE x) { f(x, x); }) {                                                                  \
-        return ApplyElemwiseComparisonOpUnsafe<CPPTYPE>(other, f);                                                     \
-    }                                                                                                                  \
-    else {                                                                                                             \
-        return ConstValue();                                                                                           \
-    }
-            switch (static_cast<ScalarKind>(scalarType)) {
-            case ScalarKind::Bool:
-                SWITCH_CASE(bool)
-            case ScalarKind::Int:
-                SWITCH_CASE(int32_t)
-            case ScalarKind::Uint:
-                SWITCH_CASE(uint32_t)
-            case ScalarKind::Float:
-                SWITCH_CASE(float)
-            case ScalarKind::Double:
-                SWITCH_CASE(double)
-            case ScalarKind::Int8:
-                SWITCH_CASE(int8_t)
-            case ScalarKind::Int16:
-                SWITCH_CASE(int16_t)
-            case ScalarKind::Int64:
-                SWITCH_CASE(int64_t)
-            case ScalarKind::Uint8:
-                SWITCH_CASE(int8_t)
-            case ScalarKind::Uint16:
-                SWITCH_CASE(uint16_t)
-            case ScalarKind::Uint64:
-                SWITCH_CASE(uint64_t)
-            case ScalarKind::Float16:
-                GLSLD_NO_IMPL();
-            default:
-                return ConstValue();
-            }
-        }
-
         auto GetBufferSize() const noexcept -> size_t
         {
             return GetScalarSize() * arraySize;
         }
 
-        auto GetBufferPtr() const noexcept -> const std::byte*
+        auto GetBufferPtr(this auto&& self) noexcept -> decltype(&self.localBuffer[0])
         {
-            if (UseHeapBuffer()) {
-                return bufferPtr;
+            if (self.UseHeapBuffer()) {
+                return self.bufferPtr;
             }
             else {
-                return &localBuffer[0];
+                return &self.localBuffer[0];
             }
         }
 
@@ -612,25 +429,18 @@ namespace glsld
             return GetBufferSize() > sizeof(localBuffer);
         }
 
-        // Note this doesn't release the memory of existing heap pointer
-        auto InitializeAsError() -> void
-        {
-            scalarType = 0;
-            arraySize  = 0;
-            rowSize    = 0;
-            colSize    = 0;
-            std::ranges::fill(localBuffer, std::byte(0));
-        }
+        // Note this doesn't release the memory of existing heap pointer. Caller must ensure heap memory is not leaked.
+        auto InitializeAsError() -> void;
 
-        // Note this doesn't release the memory of existing heap pointer
+        // Note this doesn't release the memory of existing heap pointer. Caller must ensure heap memory is not leaked.
         auto InitializeAsBlob(ScalarKind scalarType, int16_t rowSize, int16_t colSize) -> ArraySpan<std::byte>;
 
-        // Note this doesn't release the memory of existing heap pointer
-        template <typename T>
-        auto InitializeAs(int16_t rowSize, int16_t colSize) -> ArraySpan<T>
+        // Note this doesn't release the memory of existing heap pointer. Caller must ensure heap memory is not leaked.
+        template <typename CppType>
+        auto InitializeAs(int16_t rowSize, int16_t colSize) -> ArraySpan<CppType>
         {
-            auto blob = InitializeAsBlob(GetScalarKindFromCppType<T>(), rowSize, colSize);
-            return ArraySpan<T>(reinterpret_cast<T*>(blob.data()), arraySize);
+            auto blob = InitializeAsBlob(GetScalarKindFromCppType<CppType>(), rowSize, colSize);
+            return ArraySpan<CppType>(reinterpret_cast<CppType*>(blob.data()), arraySize);
         }
     };
 

--- a/glsld-core/src/Language/ConstValue.cpp
+++ b/glsld-core/src/Language/ConstValue.cpp
@@ -206,7 +206,7 @@ namespace glsld
         case ScalarKind::Int64:
             SWITCH_CASE(int64_t)
         case ScalarKind::Uint8:
-            SWITCH_CASE(int8_t)
+            SWITCH_CASE(uint8_t)
         case ScalarKind::Uint16:
             SWITCH_CASE(uint16_t)
         case ScalarKind::Uint64:
@@ -1238,7 +1238,9 @@ namespace glsld
             buffer = reinterpret_cast<std::byte*>(&localBuffer);
         }
 
-        return ArraySpan<std::byte>(buffer, GetBufferSize());
+        auto result = ArraySpan<std::byte>(buffer, GetBufferSize());
+        std::ranges::fill(result, std::byte(0));
+        return result;
     }
 
     template <std::integral T>

--- a/glsld-core/src/Language/ConstValue.cpp
+++ b/glsld-core/src/Language/ConstValue.cpp
@@ -257,7 +257,7 @@ namespace glsld
         case ScalarKind::Int64:
             SWITCH_CASE(int64_t)
         case ScalarKind::Uint8:
-            SWITCH_CASE(int8_t)
+            SWITCH_CASE(uint8_t)
         case ScalarKind::Uint16:
             SWITCH_CASE(uint16_t)
         case ScalarKind::Uint64:

--- a/glsld-core/src/Language/ConstValue.cpp
+++ b/glsld-core/src/Language/ConstValue.cpp
@@ -12,6 +12,265 @@
 
 namespace glsld
 {
+    // Assuming F is applicable to the operand, this function applies the operator in an element-wise manner and returns
+    // the result.
+    template <typename SrcScalarType, typename DstScalarType, typename F>
+    static auto ApplyElemwiseUnaryOpUnsafe(const ConstValue& operand, F f) -> ConstValue
+    {
+        GLSLD_ASSERT(operand.GetScalarKind() == GetScalarKindFromCppType<SrcScalarType>());
+
+        auto srcBuffer = operand.GetBufferAs<SrcScalarType>();
+
+        ConstValue result{GetScalarKindFromCppType<DstScalarType>(), static_cast<int16_t>(operand.GetRowSize()),
+                          static_cast<int16_t>(operand.GetColumnSize())};
+        auto dstBuffer = result.GetMutableBufferAs<DstScalarType>();
+
+        for (int i = 0; i < dstBuffer.size(); ++i) {
+            dstBuffer[i] = f(srcBuffer[i]);
+        }
+
+        return result;
+    }
+
+    // Assuming F is applicable to the operands, this function applies the operator in an element-wise manner and
+    // returns the result.
+    template <typename SrcScalarType, typename DstScalarType, typename F>
+    static auto ApplyElemwiseBinaryOpUnsafe(const ConstValue& lhs, const ConstValue& rhs, F f) -> ConstValue
+    {
+        GLSLD_ASSERT(lhs.GetScalarKind() == GetScalarKindFromCppType<SrcScalarType>());
+        GLSLD_ASSERT(rhs.GetScalarKind() == GetScalarKindFromCppType<SrcScalarType>());
+
+        auto lhsBuffer = lhs.GetBufferAs<SrcScalarType>();
+        auto rhsBuffer = rhs.GetBufferAs<SrcScalarType>();
+
+        // Case 1: both operands have the same shape, we apply the operator element-wise.
+        if (lhs.GetColumnSize() == rhs.GetColumnSize() && lhs.GetRowSize() == rhs.GetRowSize()) {
+            ConstValue result{GetScalarKindFromCppType<DstScalarType>(), static_cast<int16_t>(lhs.GetRowSize()),
+                              static_cast<int16_t>(lhs.GetColumnSize())};
+            ArraySpan<DstScalarType> dstBuffer = result.GetMutableBufferAs<DstScalarType>();
+
+            for (int i = 0; i < dstBuffer.size(); ++i) {
+                dstBuffer[i] = f(lhsBuffer[i], rhsBuffer[i]);
+            }
+
+            return result;
+        }
+        // Case 2: `<scalar> <op> <vector/matrix>`, we broadcast the scalar to all elements and apply the operator.
+        else if (lhs.IsScalar()) {
+            GLSLD_ASSERT(!rhs.IsScalar());
+
+            ConstValue result{GetScalarKindFromCppType<DstScalarType>(), static_cast<int16_t>(rhs.GetRowSize()),
+                              static_cast<int16_t>(rhs.GetColumnSize())};
+            ArraySpan<DstScalarType> dstBuffer = result.GetMutableBufferAs<DstScalarType>();
+
+            for (int i = 0; i < dstBuffer.size(); ++i) {
+                dstBuffer[i] = f(lhsBuffer[0], rhsBuffer[i]);
+            }
+
+            return result;
+        }
+        // Case 3: `<vector/matrix> <op> <scalar>`, we broadcast the scalar to all elements and apply the operator.
+        else if (rhs.IsScalar()) {
+            GLSLD_ASSERT(!lhs.IsScalar());
+
+            ConstValue result{GetScalarKindFromCppType<DstScalarType>(), static_cast<int16_t>(lhs.GetRowSize()),
+                              static_cast<int16_t>(lhs.GetColumnSize())};
+            ArraySpan<DstScalarType> dstBuffer = result.GetMutableBufferAs<DstScalarType>();
+
+            for (int i = 0; i < dstBuffer.size(); ++i) {
+                dstBuffer[i] = f(lhsBuffer[i], rhsBuffer[0]);
+            }
+
+            return result;
+        }
+        // Case 4: Incompatible shapes
+        else {
+            return ConstValue{};
+        }
+    }
+
+    template <typename DstType>
+    auto ApplyElemwiseCast(const ConstValue& operand) -> ConstValue
+    {
+        switch (operand.GetScalarKind()) {
+        case ScalarKind::Bool:
+            return ApplyElemwiseUnaryOpUnsafe<bool, DstType>(operand, [](bool x) { return static_cast<DstType>(x); });
+        case ScalarKind::Int:
+            return ApplyElemwiseUnaryOpUnsafe<int32_t, DstType>(operand,
+                                                                [](int32_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Uint:
+            return ApplyElemwiseUnaryOpUnsafe<uint32_t, DstType>(operand,
+                                                                 [](uint32_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Float:
+            return ApplyElemwiseUnaryOpUnsafe<float, DstType>(operand, [](float x) { return static_cast<DstType>(x); });
+        case ScalarKind::Double:
+            return ApplyElemwiseUnaryOpUnsafe<double, DstType>(operand,
+                                                               [](double x) { return static_cast<DstType>(x); });
+        case ScalarKind::Int8:
+            return ApplyElemwiseUnaryOpUnsafe<int8_t, DstType>(operand,
+                                                               [](int8_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Int16:
+            return ApplyElemwiseUnaryOpUnsafe<int16_t, DstType>(operand,
+                                                                [](int16_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Int64:
+            return ApplyElemwiseUnaryOpUnsafe<int64_t, DstType>(operand,
+                                                                [](int64_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Uint8:
+            return ApplyElemwiseUnaryOpUnsafe<uint8_t, DstType>(operand,
+                                                                [](uint8_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Uint16:
+            return ApplyElemwiseUnaryOpUnsafe<uint16_t, DstType>(operand,
+                                                                 [](uint16_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Uint64:
+            return ApplyElemwiseUnaryOpUnsafe<uint64_t, DstType>(operand,
+                                                                 [](uint64_t x) { return static_cast<DstType>(x); });
+        case ScalarKind::Float16:
+            // FIXME: implement this
+            return ConstValue{};
+        default:
+            return ConstValue{};
+        }
+    }
+
+    template <typename F>
+    static auto ApplyElemwiseUnaryOp(const ConstValue& operand, F f) -> ConstValue
+    {
+#define SWITCH_CASE(CPPTYPE)                                                                                           \
+    if constexpr (requires(CPPTYPE x) { f(x); }) {                                                                     \
+        return ApplyElemwiseUnaryOpUnsafe<CPPTYPE, CPPTYPE>(operand, f);                                               \
+    }                                                                                                                  \
+    else {                                                                                                             \
+        return ConstValue();                                                                                           \
+    }
+        switch (static_cast<ScalarKind>(operand.GetScalarKind())) {
+        case ScalarKind::Bool:
+            SWITCH_CASE(bool)
+        case ScalarKind::Int:
+            SWITCH_CASE(int32_t)
+        case ScalarKind::Uint:
+            SWITCH_CASE(uint32_t)
+        case ScalarKind::Float:
+            SWITCH_CASE(float)
+        case ScalarKind::Double:
+            SWITCH_CASE(double)
+        case ScalarKind::Int8:
+            SWITCH_CASE(int8_t)
+        case ScalarKind::Int16:
+            SWITCH_CASE(int16_t)
+        case ScalarKind::Int64:
+            SWITCH_CASE(int64_t)
+        case ScalarKind::Uint8:
+            SWITCH_CASE(uint8_t)
+        case ScalarKind::Uint16:
+            SWITCH_CASE(uint16_t)
+        case ScalarKind::Uint64:
+            SWITCH_CASE(uint64_t)
+        case ScalarKind::Float16:
+            GLSLD_NO_IMPL();
+        default:
+            return ConstValue();
+        }
+#undef SWITCH_CASE
+    }
+
+    template <typename F>
+    static auto ApplyElemwiseBinaryOp(const ConstValue& lhs, const ConstValue& rhs, F f) -> ConstValue
+    {
+        if (lhs.GetScalarKind() != rhs.GetScalarKind()) {
+            // Incompatible scalar kinds
+            return ConstValue{};
+        }
+
+#define SWITCH_CASE(CPPTYPE)                                                                                           \
+    if constexpr (requires(CPPTYPE x) { f(x, x); }) {                                                                  \
+        return ApplyElemwiseBinaryOpUnsafe<CPPTYPE, CPPTYPE>(lhs, rhs, f);                                             \
+    }                                                                                                                  \
+    else {                                                                                                             \
+        break;                                                                                                         \
+    }
+        switch (lhs.GetScalarKind()) {
+        case ScalarKind::Bool:
+            SWITCH_CASE(bool)
+        case ScalarKind::Int:
+            SWITCH_CASE(int32_t)
+        case ScalarKind::Uint:
+            SWITCH_CASE(uint32_t)
+        case ScalarKind::Float:
+            SWITCH_CASE(float)
+        case ScalarKind::Double:
+            SWITCH_CASE(double)
+        case ScalarKind::Int8:
+            SWITCH_CASE(int8_t)
+        case ScalarKind::Int16:
+            SWITCH_CASE(int16_t)
+        case ScalarKind::Int64:
+            SWITCH_CASE(int64_t)
+        case ScalarKind::Uint8:
+            SWITCH_CASE(int8_t)
+        case ScalarKind::Uint16:
+            SWITCH_CASE(uint16_t)
+        case ScalarKind::Uint64:
+            SWITCH_CASE(uint64_t)
+        case ScalarKind::Float16:
+            // FIXME: implement this
+            break;
+        }
+#undef SWITCH_CASE
+
+        return ConstValue{};
+    }
+
+    template <typename F>
+    static auto ApplyElemwiseComparisonOp(const ConstValue& lhs, const ConstValue& rhs, F f) -> ConstValue
+    {
+        if (lhs.GetScalarKind() != rhs.GetScalarKind()) {
+            // Incompatible scalar kinds
+            return ConstValue{};
+        }
+        if (lhs.GetRowSize() != rhs.GetRowSize() || lhs.GetColumnSize() != rhs.GetColumnSize()) {
+            // Incompatible shapes
+            return ConstValue{};
+        }
+
+#define SWITCH_CASE(CPPTYPE)                                                                                           \
+    if constexpr (requires(CPPTYPE x) { f(x, x); }) {                                                                  \
+        return ApplyElemwiseBinaryOpUnsafe<CPPTYPE, bool>(lhs, rhs, f);                                                \
+    }                                                                                                                  \
+    else {                                                                                                             \
+        break;                                                                                                         \
+    }
+        switch (lhs.GetScalarKind()) {
+        case ScalarKind::Bool:
+            SWITCH_CASE(bool)
+        case ScalarKind::Int:
+            SWITCH_CASE(int32_t)
+        case ScalarKind::Uint:
+            SWITCH_CASE(uint32_t)
+        case ScalarKind::Float:
+            SWITCH_CASE(float)
+        case ScalarKind::Double:
+            SWITCH_CASE(double)
+        case ScalarKind::Int8:
+            SWITCH_CASE(int8_t)
+        case ScalarKind::Int16:
+            SWITCH_CASE(int16_t)
+        case ScalarKind::Int64:
+            SWITCH_CASE(int64_t)
+        case ScalarKind::Uint8:
+            SWITCH_CASE(int8_t)
+        case ScalarKind::Uint16:
+            SWITCH_CASE(uint16_t)
+        case ScalarKind::Uint64:
+            SWITCH_CASE(uint64_t)
+        case ScalarKind::Float16:
+            // FIXME: implement this
+            break;
+        }
+#undef SWITCH_CASE
+
+        return ConstValue{};
+    }
+
     auto ConstValue::GetGlslType() const noexcept -> std::optional<GlslBuiltinType>
     {
         if (IsScalar()) {
@@ -432,27 +691,27 @@ namespace glsld
 
         switch (kind) {
         case ScalarKind::Bool:
-            return ApplyElemwiseCast<bool>();
+            return ApplyElemwiseCast<bool>(*this);
         case ScalarKind::Int:
-            return ApplyElemwiseCast<int32_t>();
+            return ApplyElemwiseCast<int32_t>(*this);
         case ScalarKind::Uint:
-            return ApplyElemwiseCast<uint32_t>();
+            return ApplyElemwiseCast<uint32_t>(*this);
         case ScalarKind::Float:
-            return ApplyElemwiseCast<float>();
+            return ApplyElemwiseCast<float>(*this);
         case ScalarKind::Double:
-            return ApplyElemwiseCast<double>();
+            return ApplyElemwiseCast<double>(*this);
         case ScalarKind::Int8:
-            return ApplyElemwiseCast<int8_t>();
+            return ApplyElemwiseCast<int8_t>(*this);
         case ScalarKind::Uint8:
-            return ApplyElemwiseCast<uint8_t>();
+            return ApplyElemwiseCast<uint8_t>(*this);
         case ScalarKind::Int16:
-            return ApplyElemwiseCast<int16_t>();
+            return ApplyElemwiseCast<int16_t>(*this);
         case ScalarKind::Uint16:
-            return ApplyElemwiseCast<uint16_t>();
+            return ApplyElemwiseCast<uint16_t>(*this);
         case ScalarKind::Int64:
-            return ApplyElemwiseCast<int64_t>();
+            return ApplyElemwiseCast<int64_t>(*this);
         case ScalarKind::Uint64:
-            return ApplyElemwiseCast<uint64_t>();
+            return ApplyElemwiseCast<uint64_t>(*this);
         case ScalarKind::Float16:
             GLSLD_NO_IMPL();
             return ConstValue{};
@@ -507,6 +766,17 @@ namespace glsld
         return result;
     }
 
+    auto ConstValue::Length() const -> ConstValue
+    {
+        if (colSize > 0) {
+            // FIXME: which type should it be?
+            return ConstValue::CreateScalar(static_cast<int32_t>(colSize));
+        }
+        else {
+            return ConstValue{};
+        }
+    }
+
     namespace
     {
         template <typename F, typename... Ts>
@@ -537,67 +807,57 @@ namespace glsld
 
     auto ConstValue::ElemwiseNegate() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(ExcludingBool<std::negate<>>{});
+        return ApplyElemwiseUnaryOp(*this, ExcludingBool<std::negate<>>{});
     }
     auto ConstValue::ElemwiseBitNot() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(ExcludingBoolFloat<std::bit_not<>>{});
+        return ApplyElemwiseUnaryOp(*this, ExcludingBoolFloat<std::bit_not<>>{});
     }
     auto ConstValue::ElemwiseLogicalNot() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(std::logical_not<bool>{});
-    }
-    auto ConstValue::Length() const -> ConstValue
-    {
-        if (colSize > 0) {
-            // FIXME: which type should it be?
-            return ConstValue::CreateScalar(static_cast<int32_t>(colSize));
-        }
-        else {
-            return ConstValue{};
-        }
+        return ApplyElemwiseUnaryOp(*this, std::logical_not<bool>{});
     }
 
 #pragma region Binary
     auto ConstValue::ElemwisePlus(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBool<std::plus<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBool<std::plus<>>{});
     }
     auto ConstValue::ElemwiseMinus(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBool<std::minus<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBool<std::minus<>>{});
     }
     auto ConstValue::ElemwiseMul(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBool<std::multiplies<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBool<std::multiplies<>>{});
     }
     auto ConstValue::ElemwiseDiv(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBool<std::divides<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBool<std::divides<>>{});
     }
     auto ConstValue::ElemwiseMod(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBoolFloat<std::modulus<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBoolFloat<std::modulus<>>{});
     }
     auto ConstValue::ElemwiseBitAnd(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBoolFloat<std::bit_and<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBoolFloat<std::bit_and<>>{});
     }
     auto ConstValue::ElemwiseBitOr(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBoolFloat<std::bit_or<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBoolFloat<std::bit_or<>>{});
     }
     auto ConstValue::ElemwiseBitXor(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, ExcludingBoolFloat<std::bit_xor<>>{});
+        return ApplyElemwiseBinaryOp(*this, other, ExcludingBoolFloat<std::bit_xor<>>{});
     }
     auto ConstValue::ElemwiseLogicalAnd(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, std::logical_and<bool>{});
+        return ApplyElemwiseBinaryOp(*this, other, std::logical_and<bool>{});
     }
     auto ConstValue::ElemwiseLogicalOr(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, std::logical_or<bool>{});
+        return ApplyElemwiseBinaryOp(*this, other, std::logical_or<bool>{});
     }
     auto ConstValue::ElemwiseLogicalXor(const ConstValue& other) const -> ConstValue
     {
@@ -609,7 +869,7 @@ namespace glsld
             }
         };
 
-        return ApplyElemwiseBinaryOp(other, LogicalXor{});
+        return ApplyElemwiseBinaryOp(*this, other, LogicalXor{});
     }
     auto ConstValue::ElemwiseShiftLeft(const ConstValue& other) const -> ConstValue
     {
@@ -624,27 +884,27 @@ namespace glsld
 
     auto ConstValue::ElemwiseEquals(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseComparisonOp(other, std::equal_to<>{});
+        return ApplyElemwiseComparisonOp(*this, other, std::equal_to<>{});
     }
     auto ConstValue::ElemwiseNotEquals(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseComparisonOp(other, std::not_equal_to<>{});
+        return ApplyElemwiseComparisonOp(*this, other, std::not_equal_to<>{});
     }
     auto ConstValue::ElemwiseLessThan(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseComparisonOp(other, ExcludingBool<std::less<>>{});
+        return ApplyElemwiseComparisonOp(*this, other, ExcludingBool<std::less<>>{});
     }
     auto ConstValue::ElemwiseLessThanEq(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseComparisonOp(other, ExcludingBool<std::less_equal<>>{});
+        return ApplyElemwiseComparisonOp(*this, other, ExcludingBool<std::less_equal<>>{});
     }
     auto ConstValue::ElemwiseGreaterThan(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseComparisonOp(other, ExcludingBool<std::greater<>>{});
+        return ApplyElemwiseComparisonOp(*this, other, ExcludingBool<std::greater<>>{});
     }
     auto ConstValue::ElemwiseGreaterThanEq(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseComparisonOp(other, ExcludingBool<std::greater_equal<>>{});
+        return ApplyElemwiseComparisonOp(*this, other, ExcludingBool<std::greater_equal<>>{});
     }
 #pragma endregion
 
@@ -857,80 +1117,80 @@ namespace glsld
 
     auto ConstValue::ElemwiseRadians() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Radians{});
+        return ApplyElemwiseUnaryOp(*this, Radians{});
     }
     auto ConstValue::ElemwiseDegrees() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Degrees{});
+        return ApplyElemwiseUnaryOp(*this, Degrees{});
     }
     auto ConstValue::ElemwiseSin() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Sin{});
+        return ApplyElemwiseUnaryOp(*this, Sin{});
     }
     auto ConstValue::ElemwiseCos() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Cos{});
+        return ApplyElemwiseUnaryOp(*this, Cos{});
     }
     auto ConstValue::ElemwiseAsin() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Asin{});
+        return ApplyElemwiseUnaryOp(*this, Asin{});
     }
     auto ConstValue::ElemwiseAcos() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Acos{});
+        return ApplyElemwiseUnaryOp(*this, Acos{});
     }
 
     auto ConstValue::ElemwisePow(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, Pow{});
+        return ApplyElemwiseBinaryOp(*this, other, Pow{});
     }
     auto ConstValue::ElemwiseExp() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Exp{});
+        return ApplyElemwiseUnaryOp(*this, Exp{});
     }
     auto ConstValue::ElemwiseLog() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Log{});
+        return ApplyElemwiseUnaryOp(*this, Log{});
     }
     auto ConstValue::ElemwiseExp2() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Exp2{});
+        return ApplyElemwiseUnaryOp(*this, Exp2{});
     }
     auto ConstValue::ElemwiseLog2() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Log2{});
+        return ApplyElemwiseUnaryOp(*this, Log2{});
     }
     auto ConstValue::ElemwiseSqrt() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Sqrt{});
+        return ApplyElemwiseUnaryOp(*this, Sqrt{});
     }
     auto ConstValue::ElemwiseInverseSqrt() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(InverseSqrt{});
+        return ApplyElemwiseUnaryOp(*this, InverseSqrt{});
     }
     auto ConstValue::ElemwiseAbs() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Abs{});
+        return ApplyElemwiseUnaryOp(*this, Abs{});
     }
     auto ConstValue::ElemwiseSign() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Sign{});
+        return ApplyElemwiseUnaryOp(*this, Sign{});
     }
     auto ConstValue::ElemwiseFloor() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Floor{});
+        return ApplyElemwiseUnaryOp(*this, Floor{});
     }
     auto ConstValue::ElemwiseTrunc() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Trunc{});
+        return ApplyElemwiseUnaryOp(*this, Trunc{});
     }
     auto ConstValue::ElemwiseRound() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Round{});
+        return ApplyElemwiseUnaryOp(*this, Round{});
     }
     auto ConstValue::ElemwiseCeil() const -> ConstValue
     {
-        return ApplyElemwiseUnaryOp(Ceil{});
+        return ApplyElemwiseUnaryOp(*this, Ceil{});
     }
     // auto ConstValue::ElemwiseMod(const ConstValue& other) const -> ConstValue
     // {
@@ -938,17 +1198,27 @@ namespace glsld
     // }
     auto ConstValue::ElemwiseMin(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, Min{});
+        return ApplyElemwiseBinaryOp(*this, other, Min{});
     }
     auto ConstValue::ElemwiseMax(const ConstValue& other) const -> ConstValue
     {
-        return ApplyElemwiseBinaryOp(other, Max{});
+        return ApplyElemwiseBinaryOp(*this, other, Max{});
     }
     auto ConstValue::ElemwiseClamp(const ConstValue& min, const ConstValue& max) const -> ConstValue
     {
         return ElemwiseMax(min).ElemwiseMin(max);
     }
+
 #pragma endregion
+
+    auto ConstValue::InitializeAsError() -> void
+    {
+        scalarType = 0;
+        arraySize  = 0;
+        rowSize    = 0;
+        colSize    = 0;
+        std::ranges::fill(localBuffer, std::byte(0));
+    }
 
     auto ConstValue::InitializeAsBlob(ScalarKind scalarType, int16_t rowSize, int16_t colSize) -> ArraySpan<std::byte>
     {

--- a/glsld-test/src/Compiler/ConstValueTest.cpp
+++ b/glsld-test/src/Compiler/ConstValueTest.cpp
@@ -4,208 +4,662 @@
 
 using namespace glsld;
 
+namespace
+{
+    template <typename T>
+    auto TestConstValue(const ConstValue& value, int rowSize, int columnSize, std::initializer_list<T> expected) -> bool
+    {
+        if (value.GetScalarKind() != GetScalarKindFromCppType<T>()) {
+            // The scalar type doesn't match.
+            return false;
+        }
+        if (value.GetRowSize() != rowSize || value.GetColumnSize() != columnSize) {
+            // The shape doesn't match.
+            return false;
+        }
+
+        return std::ranges::equal(value.GetBufferAs<T>(), expected, [](T actual, T expected) {
+            if constexpr (std::floating_point<T>) {
+                return actual == Catch::Approx(expected);
+            }
+            else {
+                return actual == expected;
+            }
+        });
+    }
+
+    template <typename T>
+    auto TestConstScalar(const ConstValue& value, T expected) -> bool
+    {
+        return TestConstValue(value, 1, 1, {expected});
+    }
+
+    template <typename T>
+    auto TestConstVector(const ConstValue& value, std::initializer_list<T> expected) -> bool
+    {
+        return TestConstValue(value, 1, expected.size(), expected);
+    }
+
+    template <typename T>
+    auto TestConstMatrix(const ConstValue& value, int rowSize, int columnSize, std::initializer_list<T> expected)
+        -> bool
+    {
+        GLSLD_ASSERT(expected.size() == rowSize * columnSize);
+        return TestConstValue(value, rowSize, columnSize, expected);
+    }
+
+} // namespace
+
 TEST_CASE("Compiler::ConstValueTest")
 {
     SECTION("CreateScalar")
     {
         // Test construction from bool
         ConstValue boolValue = ConstValue::CreateScalar(true);
-        REQUIRE(boolValue.IsScalarBool());
-        REQUIRE(boolValue.GetBufferAs<bool>()[0] == true);
+        REQUIRE(TestConstScalar(boolValue, true));
 
         // Test construction from int32_t
         ConstValue intValue = ConstValue::CreateScalar(static_cast<int32_t>(42));
-        REQUIRE(intValue.IsScalarInt32());
-        REQUIRE(intValue.GetBufferAs<int32_t>()[0] == 42);
+        REQUIRE(TestConstScalar(intValue, static_cast<int32_t>(42)));
 
         // Test construction from uint32_t
         ConstValue uintValue = ConstValue::CreateScalar(static_cast<uint32_t>(42));
-        REQUIRE(uintValue.IsScalarUInt32());
-        REQUIRE(uintValue.GetBufferAs<uint32_t>()[0] == 42u);
+        REQUIRE(TestConstScalar(uintValue, static_cast<uint32_t>(42)));
 
         // Test construction from float
         ConstValue floatValue = ConstValue::CreateScalar(3.14f);
-        REQUIRE(floatValue.IsScalarFloat());
-        REQUIRE(floatValue.GetBufferAs<float>()[0] == Catch::Approx(3.14f));
+        REQUIRE(TestConstScalar(floatValue, 3.14f));
 
         // Test construction from double
         ConstValue doubleValue = ConstValue::CreateScalar(2.718);
-        REQUIRE(doubleValue.IsScalarDouble());
-        REQUIRE(doubleValue.GetBufferAs<double>()[0] == Catch::Approx(2.718));
+        REQUIRE(TestConstScalar(doubleValue, 2.718));
 
         // Test construction from int8_t
         ConstValue int8Value = ConstValue::CreateScalar(int8_t(42));
-        REQUIRE(int8Value.IsScalarInt8());
-        REQUIRE(int8Value.GetBufferAs<int8_t>()[0] == 42);
+        REQUIRE(TestConstScalar(int8Value, int8_t(42)));
 
         // Test construction from uint8_t
         ConstValue uint8Value = ConstValue::CreateScalar(uint8_t(42));
-        REQUIRE(uint8Value.IsScalarUInt8());
-        REQUIRE(uint8Value.GetBufferAs<uint8_t>()[0] == 42u);
+        REQUIRE(TestConstScalar(uint8Value, uint8_t(42)));
 
         // Test construction from int16_t
         ConstValue int16Value = ConstValue::CreateScalar(int16_t(42));
-        REQUIRE(int16Value.IsScalarInt16());
-        REQUIRE(int16Value.GetBufferAs<int16_t>()[0] == 42);
+        REQUIRE(TestConstScalar(int16Value, int16_t(42)));
 
         // Test construction from uint16_t
         ConstValue uint16Value = ConstValue::CreateScalar(uint16_t(42));
-        REQUIRE(uint16Value.IsScalarUInt16());
-        REQUIRE(uint16Value.GetBufferAs<uint16_t>()[0] == 42u);
+        REQUIRE(TestConstScalar(uint16Value, uint16_t(42)));
 
         // Test construction from int64_t
         ConstValue int64Value = ConstValue::CreateScalar(int64_t(42));
-        REQUIRE(int64Value.IsScalarInt64());
-        REQUIRE(int64Value.GetBufferAs<int64_t>()[0] == 42);
+        REQUIRE(TestConstScalar(int64Value, int64_t(42)));
 
         // Test construction from uint64_t
         ConstValue uint64Value = ConstValue::CreateScalar(uint64_t(42));
-        REQUIRE(uint64Value.IsScalarUInt64());
-        REQUIRE(uint64Value.GetBufferAs<uint64_t>()[0] == 42u);
+        REQUIRE(TestConstScalar(uint64Value, uint64_t(42)));
     }
 
     SECTION("CreateVector")
     {
         // Test construction of a 2-element int vector
         ConstValue ivec2 = ConstValue::CreateVector<int32_t>({1, 2});
-        REQUIRE(ivec2.GetScalarKind() == ScalarKind::Int);
-        REQUIRE(ivec2.GetRowSize() == 1);
-        REQUIRE(ivec2.GetColumnSize() == 2);
-        REQUIRE(std::ranges::equal(ivec2.GetBufferAs<int32_t>(), std::initializer_list<int32_t>{1, 2}));
+        REQUIRE(TestConstVector(ivec2, {1, 2}));
 
         // Test construction of a 3-element int vector
         ConstValue ivec3 = ConstValue::CreateVector<int32_t>({1, 2, 3});
-        REQUIRE(ivec3.GetScalarKind() == ScalarKind::Int);
-        REQUIRE(ivec3.GetRowSize() == 1);
-        REQUIRE(ivec3.GetColumnSize() == 3);
-        REQUIRE(std::ranges::equal(ivec3.GetBufferAs<int32_t>(), std::initializer_list<int32_t>{1, 2, 3}));
+        REQUIRE(TestConstVector(ivec3, {1, 2, 3}));
 
         // Test construction of a 4-element int vector
         ConstValue ivec4 = ConstValue::CreateVector<int32_t>({1, 2, 3, 4});
-        REQUIRE(ivec4.GetScalarKind() == ScalarKind::Int);
-        REQUIRE(ivec4.GetRowSize() == 1);
-        REQUIRE(ivec4.GetColumnSize() == 4);
-        REQUIRE(std::ranges::equal(ivec4.GetBufferAs<int32_t>(), std::initializer_list<int32_t>{1, 2, 3, 4}));
+        REQUIRE(TestConstVector(ivec4, {1, 2, 3, 4}));
 
         // Test construction of a 4-element float vector
         ConstValue vec4 = ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f});
-        REQUIRE(vec4.GetScalarKind() == ScalarKind::Float);
-        REQUIRE(vec4.GetRowSize() == 1);
-        REQUIRE(vec4.GetColumnSize() == 4);
-        REQUIRE(std::ranges::equal(vec4.GetBufferAs<float>(), std::initializer_list<float>{1.0f, 2.0f, 3.0f, 4.0f}));
+        REQUIRE(TestConstVector(vec4, {1.0f, 2.0f, 3.0f, 4.0f}));
     }
 
-    SECTION("ScalarArithmetics")
-    {
-        // Test ElemwisePlus
-        ConstValue b0 = ConstValue::CreateScalar(false);
-        ConstValue i3 = ConstValue::CreateScalar(3);
-        ConstValue i4 = ConstValue::CreateScalar(4);
-        ConstValue f3 = ConstValue::CreateScalar(3.0f);
-        ConstValue f4 = ConstValue::CreateScalar(4.0f);
+    // Prepare some constants for later tests
+    ConstValue b0 = ConstValue::CreateScalar(false);
+    ConstValue b1 = ConstValue::CreateScalar(true);
+    ConstValue i0 = ConstValue::CreateScalar(0);
+    ConstValue i1 = ConstValue::CreateScalar(1);
+    ConstValue i2 = ConstValue::CreateScalar(2);
+    ConstValue i3 = ConstValue::CreateScalar(3);
+    ConstValue i4 = ConstValue::CreateScalar(4);
+    ConstValue f2_75 = ConstValue::CreateScalar(2.75f);
+    ConstValue f3 = ConstValue::CreateScalar(3.0f);
+    ConstValue f4 = ConstValue::CreateScalar(4.0f);
 
+    ConstValue bv4_0101 = ConstValue::CreateVector<bool>({false, true, false, true});
+    ConstValue bv4_0011 = ConstValue::CreateVector<bool>({false, false, true, true});
+    ConstValue iv2_12   = ConstValue::CreateVector<int32_t>({1, 2});
+    ConstValue iv2_45   = ConstValue::CreateVector<int32_t>({4, 5});
+    ConstValue iv4_0123 = ConstValue::CreateVector<int32_t>({0, 1, 2, 3});
+    ConstValue iv4_0024 = ConstValue::CreateVector<int32_t>({0, 0, 2, 4});
+    ConstValue iv4_1111 = ConstValue::CreateVector<int32_t>({1, 1, 1, 1});
+    ConstValue uv4_0123 = ConstValue::CreateVector<uint32_t>({0, 1, 2, 3});
+    ConstValue v2_12    = ConstValue::CreateVector<float>({1.0f, 2.0f});
+    ConstValue v3_123   = ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f});
+    ConstValue v4_0123  = ConstValue::CreateVector<float>({0.0f, 1.0f, 2.0f, 3.0f});
+    ConstValue v4_1111  = ConstValue::CreateVector<float>({1.0f, 1.0f, 1.0f, 1.0f});
+
+    ConstValue im2x3_123456 = ConstValue::ConstructMatrix(ConstValue::CreateVector<int32_t>({1, 2, 3, 4, 5, 6}),
+                                                          ScalarKind::Int, 2, 3);
+    ConstValue m2x3_123456  = ConstValue::ConstructMatrix(ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f,
+                                                                                           5.0f, 6.0f}),
+                                                          ScalarKind::Float, 2, 3);
+    ConstValue m3x2_123456  = ConstValue::ConstructMatrix(ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f,
+                                                                                           5.0f, 6.0f}),
+                                                          ScalarKind::Float, 3, 2);
+
+    SECTION("Unary Element-wise Arithmetics")
+    {
+        SECTION("Negate")
+        {
+            // Tests element-wise negation of scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseNegate(), int32_t(-3)));
+            REQUIRE(TestConstScalar(f3.ElemwiseNegate(), -3.0f));
+
+            // Element-wise negation of bools is not defined, should return error
+            REQUIRE(b0.ElemwiseNegate().IsError());
+
+            // Tests element-wise negation of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseNegate(), {0, -1, -2, -3}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseNegate(), {-0.0f, -1.0f, -2.0f, -3.0f}));
+        }
+
+        SECTION("BitNot")
+        {
+            // Tests element-wise bitwise-not of scalar integers
+            REQUIRE(TestConstScalar(i3.ElemwiseBitNot(), int32_t(~3)));
+
+            // Element-wise bitwise-not of bools and floats is not defined, should return error
+            REQUIRE(b0.ElemwiseBitNot().IsError());
+            REQUIRE(f3.ElemwiseBitNot().IsError());
+
+            // Tests element-wise bitwise-not of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitNot(), {~0, ~1, ~2, ~3}));
+        }
+
+        SECTION("LogicalNot")
+        {
+            // Tests element-wise logical-not of bool scalars
+            REQUIRE(TestConstScalar(b0.ElemwiseLogicalNot(), true));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalNot(), false));
+
+            // Tests element-wise logical-not of vectors
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalNot(), {true, false, true, false}));
+        }
+    }
+
+    SECTION("Binary Element-wise Arithmetics")
+    {
         SECTION("Plus")
         {
-            ConstValue result = i3.ElemwisePlus(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == 7);
+            // Tests element-wise addition of scalars
+            REQUIRE(TestConstScalar(i3.ElemwisePlus(i4), int32_t(7)));
+            REQUIRE(TestConstScalar(f3.ElemwisePlus(f4), 3.0f + 4.0f));
 
-            result = f3.ElemwisePlus(f4);
-            REQUIRE(result.IsScalarFloat());
-            REQUIRE(result.GetBufferAs<float>()[0] == Catch::Approx(3.0f + 4.0f));
+            // Element-wise addition of bools is not defined, should return error
+            REQUIRE(b0.ElemwisePlus(b0).IsError());
+
+            // Tests element-wise addition of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwisePlus(iv4_1111), {1, 2, 3, 4}));
+            REQUIRE(TestConstVector(v4_0123.ElemwisePlus(v4_1111), {1.0f, 2.0f, 3.0f, 4.0f}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwisePlus(i1), {1, 2, 3, 4}));
+            REQUIRE(TestConstVector(i1.ElemwisePlus(iv4_0123), {1, 2, 3, 4}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwisePlus(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwisePlus(v4_0123).IsError());
         }
 
         SECTION("Minus")
         {
-            ConstValue result = i3.ElemwiseMinus(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == -1);
+            // Tests element-wise subtraction of scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseMinus(i4), int32_t(-1)));
+            REQUIRE(TestConstScalar(f3.ElemwiseMinus(f4), 3.0f - 4.0f));
 
-            result = f3.ElemwiseMinus(f4);
-            REQUIRE(result.IsScalarFloat());
-            REQUIRE(result.GetBufferAs<float>()[0] == Catch::Approx(3.0f - 4.0f));
+            // Element-wise subtraction of bools is not defined, should return error
+            REQUIRE(b0.ElemwiseMinus(b0).IsError());
+
+            // Tests element-wise subtraction of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseMinus(iv4_1111), {-1, 0, 1, 2}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseMinus(v4_1111), {-1.0f, 0.0f, 1.0f, 2.0f}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseMinus(i1), {-1, 0, 1, 2}));
+            REQUIRE(TestConstVector(i1.ElemwiseMinus(iv4_0123), {1, 0, -1, -2}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseMinus(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseMinus(v4_0123).IsError());
         }
 
         SECTION("Multiply")
         {
-            ConstValue result = i3.ElemwiseMul(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == 12);
+            // Tests element-wise multiplication of scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseMul(i4), int32_t(12)));
+            REQUIRE(TestConstScalar(f3.ElemwiseMul(f4), 3.0f * 4.0f));
 
-            result = f3.ElemwiseMul(f4);
-            REQUIRE(result.IsScalarFloat());
-            REQUIRE(result.GetBufferAs<float>()[0] == Catch::Approx(3.0f * 4.0f));
+            // Element-wise multiplication of bools is not defined, should return error
+            REQUIRE(b0.ElemwiseMul(b0).IsError());
+
+            // Tests element-wise multiplication of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseMul(iv4_1111), {0, 1, 2, 3}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseMul(v4_1111), {0.0f, 1.0f, 2.0f, 3.0f}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseMul(i3), {0, 3, 6, 9}));
+            REQUIRE(TestConstVector(i3.ElemwiseMul(iv4_0123), {0, 3, 6, 9}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseMul(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseMul(v4_0123).IsError());
         }
 
         SECTION("Divide")
         {
-            ConstValue result = i3.ElemwiseDiv(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == 0);
+            // Tests element-wise division of scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseDiv(i4), int32_t(0)));
+            REQUIRE(TestConstScalar(f3.ElemwiseDiv(f4), 3.0f / 4.0f));
 
-            result = f3.ElemwiseDiv(f4);
-            REQUIRE(result.IsScalarFloat());
-            REQUIRE(result.GetBufferAs<float>()[0] == Catch::Approx(3.0f / 4.0f));
+            // Element-wise division of bools is not defined, should return error
+            REQUIRE(b0.ElemwiseDiv(b0).IsError());
+
+            // Tests element-wise division of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseDiv(iv4_1111), {0, 1, 2, 3}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseDiv(v4_1111), {0.0f, 1.0f, 2.0f, 3.0f}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseDiv(i1), {0, 1, 2, 3}));
+            REQUIRE(TestConstVector(i4.ElemwiseDiv(iv4_1111), {4, 4, 4, 4}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseDiv(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseDiv(v4_0123).IsError());
         }
 
         SECTION("Modulo")
         {
-            ConstValue result = i3.ElemwiseMod(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == 3);
+            // Tests element-wise modulo of scalar integers
+            REQUIRE(TestConstScalar(i3.ElemwiseMod(i4), int32_t(3)));
 
-            result = f3.ElemwiseMod(f4);
-            REQUIRE(result.IsError());
+            // Element-wise modulo of bools and floats is not defined, should return error
+            REQUIRE(b0.ElemwiseMod(b0).IsError());
+            REQUIRE(f3.ElemwiseMod(f4).IsError());
+
+            // Tests element-wise modulo of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseMod(iv4_1111), {0, 0, 0, 0}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseMod(i1), {0, 0, 0, 0}));
+            REQUIRE(TestConstVector(i3.ElemwiseMod(iv4_1111), {0, 0, 0, 0}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseMod(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseMod(v4_0123).IsError());
         }
 
         SECTION("BitAnd")
         {
-            ConstValue result = i3.ElemwiseBitAnd(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == 0);
+            // Tests element-wise bitwise-and of scalar integers
+            REQUIRE(TestConstScalar(i3.ElemwiseBitAnd(i4), int32_t(0)));
+
+            // Element-wise bitwise-and of bools and floats is not defined, should return error
+            REQUIRE(b0.ElemwiseBitAnd(b0).IsError());
+            REQUIRE(f3.ElemwiseBitAnd(f4).IsError());
+
+            // Tests element-wise bitwise-and of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitAnd(iv4_1111), {0, 1, 0, 1}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitAnd(i1), {0, 1, 0, 1}));
+            REQUIRE(TestConstVector(i1.ElemwiseBitAnd(iv4_0123), {0, 1, 0, 1}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseBitAnd(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseBitAnd(v4_0123).IsError());
         }
 
         SECTION("BitOr")
         {
-            ConstValue result = i3.ElemwiseBitOr(i4);
-            REQUIRE(result.IsScalarInt32());
-            REQUIRE(result.GetBufferAs<int32_t>()[0] == 7);
+            // Tests element-wise bitwise-or of scalar integers
+            REQUIRE(TestConstScalar(i3.ElemwiseBitOr(i4), int32_t(7)));
+
+            // Element-wise bitwise-or of bools and floats is not defined, should return error
+            REQUIRE(b0.ElemwiseBitOr(b0).IsError());
+            REQUIRE(f3.ElemwiseBitOr(f4).IsError());
+
+            // Tests element-wise bitwise-or of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitOr(iv4_1111), {1, 1, 3, 3}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitOr(i1), {1, 1, 3, 3}));
+            REQUIRE(TestConstVector(i1.ElemwiseBitOr(iv4_0123), {1, 1, 3, 3}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseBitOr(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseBitOr(v4_0123).IsError());
+        }
+
+        SECTION("BitXor")
+        {
+            // Tests element-wise bitwise-xor of scalar integers
+            REQUIRE(TestConstScalar(i3.ElemwiseBitXor(i4), int32_t(7)));
+
+            // Element-wise bitwise-xor of bools and floats is not defined, should return error
+            REQUIRE(b0.ElemwiseBitXor(b0).IsError());
+            REQUIRE(f3.ElemwiseBitXor(f4).IsError());
+
+            // Tests element-wise bitwise-xor of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitXor(iv4_1111), {1, 0, 3, 2}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseBitXor(i1), {1, 0, 3, 2}));
+            REQUIRE(TestConstVector(i1.ElemwiseBitXor(iv4_0123), {1, 0, 3, 2}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseBitXor(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseBitXor(v4_0123).IsError());
+        }
+
+        SECTION("LogicalAnd")
+        {
+            // Tests element-wise logical-and of bool scalars
+            REQUIRE(TestConstScalar(b0.ElemwiseLogicalAnd(b0), false));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalAnd(b0), false));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalAnd(b1), true));
+
+            // Tests element-wise logical-and of vectors
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalAnd(bv4_0011), {false, false, false, true}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalAnd(b1), {false, true, false, true}));
+            REQUIRE(TestConstVector(b1.ElemwiseLogicalAnd(bv4_0101), {false, true, false, true}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(bv4_0101.ElemwiseLogicalAnd(ConstValue::CreateVector<bool>({true, false})).IsError());
+            REQUIRE(bv4_0101.ElemwiseLogicalAnd(iv4_0123).IsError());
+        }
+
+        SECTION("LogicalOr")
+        {
+            // Tests element-wise logical-or of bool scalars
+            REQUIRE(TestConstScalar(b0.ElemwiseLogicalOr(b0), false));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalOr(b0), true));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalOr(b1), true));
+
+            // Tests element-wise logical-or of vectors
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalOr(bv4_0011), {false, true, true, true}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalOr(b1), {true, true, true, true}));
+            REQUIRE(TestConstVector(b0.ElemwiseLogicalOr(bv4_0101), {false, true, false, true}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(bv4_0101.ElemwiseLogicalOr(ConstValue::CreateVector<bool>({true, false})).IsError());
+            REQUIRE(bv4_0101.ElemwiseLogicalOr(iv4_0123).IsError());
+        }
+
+        SECTION("LogicalXor")
+        {
+            // Tests element-wise logical-xor of bool scalars
+            REQUIRE(TestConstScalar(b0.ElemwiseLogicalXor(b0), false));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalXor(b0), true));
+            REQUIRE(TestConstScalar(b1.ElemwiseLogicalXor(b1), false));
+
+            // Tests element-wise logical-xor of vectors
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalXor(bv4_0011), {false, true, true, false}));
+
+            // Tests broadcasting of scalar to vector
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseLogicalXor(b1), {true, false, true, false}));
+            REQUIRE(TestConstVector(b0.ElemwiseLogicalXor(bv4_0101), {false, true, false, true}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(bv4_0101.ElemwiseLogicalXor(ConstValue::CreateVector<bool>({true, false})).IsError());
+            REQUIRE(bv4_0101.ElemwiseLogicalXor(iv4_0123).IsError());
+        }
+
+        SECTION("Shift")
+        {
+            // FIXME: Shift operators are not implemented yet.
+            REQUIRE(i1.ElemwiseShiftLeft(i1).IsError());
+            REQUIRE(i1.ElemwiseShiftRight(i1).IsError());
+            REQUIRE(iv4_0123.ElemwiseShiftLeft(iv4_1111).IsError());
+            REQUIRE(iv4_0123.ElemwiseShiftRight(iv4_1111).IsError());
         }
     }
 
     SECTION("Comparison")
     {
-        ConstValue lhs    = ConstValue::CreateScalar(5);
-        ConstValue rhs    = ConstValue::CreateScalar(5);
-        ConstValue result = lhs.ElemwiseEquals(rhs);
-        REQUIRE(result.IsScalarBool());
-        REQUIRE(result.GetBoolValue() == true);
+        SECTION("Equals")
+        {
+            // Tests element-wise equality of scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseEquals(i3), true));
+            REQUIRE(TestConstScalar(i3.ElemwiseEquals(i4), false));
+            REQUIRE(TestConstScalar(f3.ElemwiseEquals(f3), true));
+            REQUIRE(TestConstScalar(b0.ElemwiseEquals(b1), false));
 
-        rhs    = ConstValue::CreateScalar(3);
-        result = lhs.ElemwiseGreaterThan(rhs);
-        REQUIRE(result.GetBoolValue() == true);
+            // Tests element-wise equality of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseEquals(iv4_0024), {true, false, true, false}));
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseEquals(bv4_0011), {true, false, false, true}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseEquals(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseEquals(v4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseEquals(i1).IsError());
+        }
+
+        SECTION("NotEquals")
+        {
+            // Tests element-wise inequality of scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseNotEquals(i3), false));
+            REQUIRE(TestConstScalar(i3.ElemwiseNotEquals(i4), true));
+            REQUIRE(TestConstScalar(f3.ElemwiseNotEquals(f4), true));
+            REQUIRE(TestConstScalar(b0.ElemwiseNotEquals(b1), true));
+
+            // Tests element-wise inequality of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseNotEquals(iv4_0024), {false, true, false, true}));
+            REQUIRE(TestConstVector(bv4_0101.ElemwiseNotEquals(bv4_0011), {false, true, true, false}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseNotEquals(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseNotEquals(v4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseNotEquals(i1).IsError());
+        }
+
+        SECTION("LessThan")
+        {
+            // Tests element-wise less-than of numeric scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseLessThan(i4), true));
+            REQUIRE(TestConstScalar(i4.ElemwiseLessThan(i3), false));
+            REQUIRE(TestConstScalar(f3.ElemwiseLessThan(f4), true));
+
+            // Element-wise less-than of bools is not defined, should return error
+            REQUIRE(b0.ElemwiseLessThan(b1).IsError());
+
+            // Tests element-wise less-than of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseLessThan(iv4_0024), {false, false, false, true}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseLessThan(v4_1111), {true, false, false, false}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseLessThan(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseLessThan(v4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseLessThan(i1).IsError());
+        }
+
+        SECTION("LessThanEq")
+        {
+            // Tests element-wise less-than-or-equal of numeric scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseLessThanEq(i4), true));
+            REQUIRE(TestConstScalar(i4.ElemwiseLessThanEq(i3), false));
+            REQUIRE(TestConstScalar(f3.ElemwiseLessThanEq(f3), true));
+
+            // Element-wise less-than-or-equal of bools is not defined, should return error
+            REQUIRE(b0.ElemwiseLessThanEq(b1).IsError());
+
+            // Tests element-wise less-than-or-equal of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseLessThanEq(iv4_0024), {true, false, true, true}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseLessThanEq(v4_1111), {true, true, false, false}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseLessThanEq(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseLessThanEq(v4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseLessThanEq(i1).IsError());
+        }
+
+        SECTION("GreaterThan")
+        {
+            // Tests element-wise greater-than of numeric scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseGreaterThan(i4), false));
+            REQUIRE(TestConstScalar(i4.ElemwiseGreaterThan(i3), true));
+            REQUIRE(TestConstScalar(f4.ElemwiseGreaterThan(f3), true));
+
+            // Element-wise greater-than of bools is not defined, should return error
+            REQUIRE(b1.ElemwiseGreaterThan(b0).IsError());
+
+            // Tests element-wise greater-than of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseGreaterThan(iv4_0024), {false, true, false, false}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseGreaterThan(v4_1111), {false, false, true, true}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseGreaterThan(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseGreaterThan(v4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseGreaterThan(i1).IsError());
+        }
+
+        SECTION("GreaterThanEq")
+        {
+            // Tests element-wise greater-than-or-equal of numeric scalars
+            REQUIRE(TestConstScalar(i3.ElemwiseGreaterThanEq(i4), false));
+            REQUIRE(TestConstScalar(i4.ElemwiseGreaterThanEq(i3), true));
+            REQUIRE(TestConstScalar(f3.ElemwiseGreaterThanEq(f3), true));
+
+            // Element-wise greater-than-or-equal of bools is not defined, should return error
+            REQUIRE(b1.ElemwiseGreaterThanEq(b0).IsError());
+
+            // Tests element-wise greater-than-or-equal of vectors
+            REQUIRE(TestConstVector(iv4_0123.ElemwiseGreaterThanEq(iv4_0024), {true, true, true, false}));
+            REQUIRE(TestConstVector(v4_0123.ElemwiseGreaterThanEq(v4_1111), {false, true, true, true}));
+
+            // Incompatible shapes or scalar types should return error
+            REQUIRE(iv2_12.ElemwiseGreaterThanEq(iv4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseGreaterThanEq(v4_0123).IsError());
+            REQUIRE(iv4_0123.ElemwiseGreaterThanEq(i1).IsError());
+        }
+    }
+
+    SECTION("CastScalar")
+    {
+        SECTION("Scalar")
+        {
+            REQUIRE(i2.CastScalar(ScalarKind::Int) == ConstValue::CreateScalar(int32_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Bool), true));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Uint), uint32_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Float), 2.0f));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Double), 2.0));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Int8), int8_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Uint8), uint8_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Int16), int16_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Uint16), uint16_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Int64), int64_t(2)));
+            REQUIRE(TestConstScalar(i2.CastScalar(ScalarKind::Uint64), uint64_t(2)));
+
+            REQUIRE(TestConstScalar(i0.CastScalar(ScalarKind::Bool), false));
+            REQUIRE(TestConstScalar(f2_75.CastScalar(ScalarKind::Int), int32_t(2)));
+            REQUIRE(TestConstScalar(b1.CastScalar(ScalarKind::Float), 1.0f));
+        }
+
+        SECTION("Vector")
+        {
+            REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Bool), {false, true, true, true}));
+            REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Float), {0.0f, 1.0f, 2.0f, 3.0f}));
+            REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Double), {0.0, 1.0, 2.0, 3.0}));
+            REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Uint64), {uint64_t(0), uint64_t(1), uint64_t(2),
+                                                                              uint64_t(3)}));
+
+            REQUIRE(TestConstVector(bv4_0101.CastScalar(ScalarKind::Int), {0, 1, 0, 1}));
+        }
+
+        SECTION("Matrix")
+        {
+            REQUIRE(TestConstMatrix(im2x3_123456.CastScalar(ScalarKind::Float), 2, 3,
+                                    {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
+            REQUIRE(TestConstMatrix(im2x3_123456.CastScalar(ScalarKind::Bool), 2, 3,
+                                    {true, true, true, true, true, true}));
+        }
+
+        SECTION("Error")
+        {
+            REQUIRE(ConstValue{}.CastScalar(ScalarKind::Int).IsError());
+            REQUIRE(i1.CastScalar(static_cast<ScalarKind>(999)).IsError());
+        }
     }
 
     SECTION("GetElement")
     {
-        ConstValue uvec4 = ConstValue::CreateVector<uint32_t>({0, 1, 2, 3});
+        REQUIRE(ConstValue{}.GetElement(0).IsError());
 
-        REQUIRE(uvec4.GetElement(-1) == ConstValue{});
-        REQUIRE(uvec4.GetElement(0) == ConstValue::CreateScalar(uint32_t(0)));
-        REQUIRE(uvec4.GetElement(1) == ConstValue::CreateScalar(uint32_t(1)));
-        REQUIRE(uvec4.GetElement(2) == ConstValue::CreateScalar(uint32_t(2)));
-        REQUIRE(uvec4.GetElement(3) == ConstValue::CreateScalar(uint32_t(3)));
-        REQUIRE(uvec4.GetElement(4) == ConstValue{});
+        REQUIRE(i3.GetElement(-1).IsError());
+        REQUIRE(i3.GetElement(0) == ConstValue::CreateScalar(int32_t(3)));
+        REQUIRE(i3.GetElement(1).IsError());
+
+        REQUIRE(uv4_0123.GetElement(-1) == ConstValue{});
+        REQUIRE(uv4_0123.GetElement(0) == ConstValue::CreateScalar(uint32_t(0)));
+        REQUIRE(uv4_0123.GetElement(1) == ConstValue::CreateScalar(uint32_t(1)));
+        REQUIRE(uv4_0123.GetElement(2) == ConstValue::CreateScalar(uint32_t(2)));
+        REQUIRE(uv4_0123.GetElement(3) == ConstValue::CreateScalar(uint32_t(3)));
+        REQUIRE(uv4_0123.GetElement(4) == ConstValue{});
+
+        REQUIRE(TestConstVector(m2x3_123456.GetElement(0), {1.0f, 2.0f, 3.0f}));
+        REQUIRE(TestConstVector(m2x3_123456.GetElement(1), {4.0f, 5.0f, 6.0f}));
+        REQUIRE(m2x3_123456.GetElement(-1).IsError());
+        REQUIRE(m2x3_123456.GetElement(2).IsError());
     }
 
     SECTION("GetSwizzle")
     {
-        ConstValue uvec4 = ConstValue::CreateVector<uint32_t>({0, 1, 2, 3});
+        REQUIRE(ConstValue{}.GetSwizzle(SwizzleDesc::Parse("x")).IsError());
 
-        REQUIRE(uvec4.GetSwizzle(SwizzleDesc::Parse("xyzw")) == ConstValue::CreateVector<uint32_t>({0, 1, 2, 3}));
-        REQUIRE(uvec4.GetSwizzle(SwizzleDesc::Parse("wzyx")) == ConstValue::CreateVector<uint32_t>({3, 2, 1, 0}));
-        REQUIRE(uvec4.GetSwizzle(SwizzleDesc::Parse("xxzz")) == ConstValue::CreateVector<uint32_t>({0, 0, 2, 2}));
-        REQUIRE(uvec4.GetSwizzle(SwizzleDesc::Parse("yy")) == ConstValue::CreateVector<uint32_t>({1, 1}));
+        REQUIRE(i3.GetSwizzle(SwizzleDesc::Parse("x")) == ConstValue::CreateScalar(int32_t(3)));
+        REQUIRE(TestConstVector(i3.GetSwizzle(SwizzleDesc::Parse("xxxx")), {3, 3, 3, 3}));
+        REQUIRE(i3.GetSwizzle(SwizzleDesc::Parse("y")).IsError());
+
+        REQUIRE(iv2_45.GetSwizzle(SwizzleDesc::Parse("x")) == ConstValue::CreateScalar(int32_t(4)));
+        REQUIRE(iv2_45.GetSwizzle(SwizzleDesc::Parse("y")) == ConstValue::CreateScalar(int32_t(5)));
+        REQUIRE(TestConstVector(iv2_45.GetSwizzle(SwizzleDesc::Parse("yx")), {5, 4}));
+        REQUIRE(TestConstVector(iv2_45.GetSwizzle(SwizzleDesc::Parse("xxxx")), {4, 4, 4, 4}));
+        REQUIRE(iv2_45.GetSwizzle(SwizzleDesc::Parse("z")).IsError());
+
+        REQUIRE(TestConstVector(v3_123.GetSwizzle(SwizzleDesc::Parse("xyz")), {1.0f, 2.0f, 3.0f}));
+        REQUIRE(TestConstVector(v3_123.GetSwizzle(SwizzleDesc::Parse("zyx")), {3.0f, 2.0f, 1.0f}));
+        REQUIRE(TestConstVector(v3_123.GetSwizzle(SwizzleDesc::Parse("rrg")), {1.0f, 1.0f, 2.0f}));
+        REQUIRE(TestConstVector(v3_123.GetSwizzle(SwizzleDesc::Parse("stp")), {1.0f, 2.0f, 3.0f}));
+        REQUIRE(v3_123.GetSwizzle(SwizzleDesc::Parse("w")).IsError());
+
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("x")) == ConstValue::CreateScalar(uint32_t(0)));
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("xyzw")) == ConstValue::CreateVector<uint32_t>({0, 1, 2, 3}));
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("wzyx")) == ConstValue::CreateVector<uint32_t>({3, 2, 1, 0}));
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("xxzz")) == ConstValue::CreateVector<uint32_t>({0, 0, 2, 2}));
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("yy")) == ConstValue::CreateVector<uint32_t>({1, 1}));
+
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("")).IsError());
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("xyzwx")).IsError());
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("xr")).IsError());
+        REQUIRE(uv4_0123.GetSwizzle(SwizzleDesc::Parse("bad")).IsError());
+    }
+
+    SECTION("Length")
+    {
+        REQUIRE(ConstValue{}.Length().IsError());
+        REQUIRE(TestConstScalar(i3.Length(), int32_t(1)));
+        REQUIRE(TestConstScalar(v2_12.Length(), int32_t(2)));
+        REQUIRE(TestConstScalar(v4_0123.Length(), int32_t(4)));
+        REQUIRE(TestConstScalar(m2x3_123456.Length(), int32_t(3)));
+        REQUIRE(TestConstScalar(m3x2_123456.Length(), int32_t(2)));
     }
 
     // FIXME: add more tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit constructor for initializing constant values with scalar kind and dimensions
  * Added mutable buffer accessors for updating constant value data

* **Refactor**
  * Reorganized internal element-wise operation handlers for improved maintainability

* **Tests**
  * Expanded comprehensive test coverage for operations, comparisons, casting, and data accessors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daiyousei-qz/glsld/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->