### PR TITLE
Fix ODR violation in catch2 StringMaker specialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if(GLSLD_BUILD_UNIT_TEST)
     CPMAddPackage(
         NAME catch2
         GITHUB_REPOSITORY catchorg/Catch2
-        GIT_TAG 88abf9bf325c798c33f54f6b9220ef885b267f4f # v3.12.0
+        GIT_TAG 6ee0826dcae55ed1e06b2c5701981221e979e1e6 # v3.15.0
         OPTIONS "CATCH_BUILD_STATIC_LIBRARY ON"
     )
 
@@ -202,6 +202,7 @@ if(GLSLD_BUILD_UNIT_TEST)
     target_link_libraries(glsld-test PRIVATE glsld-core glsld-server)
 
     target_link_libraries(glsld-test PRIVATE Catch2::Catch2WithMain)
+    target_compile_definitions(glsld-test PRIVATE CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS)
 
     catch_discover_tests(glsld-test)
 

--- a/glsld-test/include/Catch2Wrapper.h
+++ b/glsld-test/include/Catch2Wrapper.h
@@ -1,27 +1,14 @@
 #pragma once
+#include "Support/EnumReflection.h"
 #include "Support/StringView.h"
 #include "Basic/SourceInfo.h"
-#include "Ast/Base.h"
 
-#include "Support/EnumReflection.h"
-#include "catch2/catch_tostring.hpp"
+#include <catch2/catch_tostring.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 namespace Catch
 {
-    template <typename T>
-    struct StringMaker<std::optional<T>>
-    {
-        static auto convert(const std::optional<T>& value) -> std::string
-        {
-            if (value.has_value()) {
-                return StringMaker<T>::convert(*value);
-            }
-            else {
-                return "std::nullopt";
-            }
-        }
-    };
-
     template <>
     struct StringMaker<glsld::StringView>
     {
@@ -51,10 +38,11 @@ namespace Catch
         }
     };
 
-    template <>
-    struct StringMaker<glsld::AstNodeTag>
+    template <typename E>
+        requires std::is_enum_v<E>
+    struct StringMaker<E>
     {
-        static auto convert(const glsld::AstNodeTag& value) -> std::string
+        static auto convert(E value) -> std::string
         {
             return glsld::EnumToString(value).Str();
         }

--- a/glsld-test/include/CompilerTestFixture.h
+++ b/glsld-test/include/CompilerTestFixture.h
@@ -1,13 +1,12 @@
 #pragma once
 
 #include "AstMatcher.h"
+#include "Catch2Wrapper.h"
 
 #include "Support/StringView.h"
 #include "Compiler/CompilerInvocation.h"
 #include "Compiler/PPCallback.h"
 
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
 #include <fmt/ranges.h>
 
 #include <tuple>

--- a/glsld-test/include/ServerTestFixture.h
+++ b/glsld-test/include/ServerTestFixture.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include "StringMaker.h"
+#include "Catch2Wrapper.h"
 
 #include "Basic/SourceInfo.h"
 #include "Support/StringMap.h"
 #include "Compiler/CompilerInvocation.h"
 #include "Server/LanguageQueryInfo.h"
-
-#include <catch2/catch_message.hpp>
-#include <catch2/catch_test_macros.hpp>
 
 namespace glsld
 {

--- a/glsld-test/src/Compiler/ConstValueTest.cpp
+++ b/glsld-test/src/Compiler/ConstValueTest.cpp
@@ -1,6 +1,6 @@
+#include "Catch2Wrapper.h"
+
 #include "Language/ConstValue.h"
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/catch_approx.hpp>
 
 using namespace glsld;
 
@@ -119,16 +119,16 @@ TEST_CASE("Compiler::ConstValueTest")
     }
 
     // Prepare some constants for later tests
-    ConstValue b0 = ConstValue::CreateScalar(false);
-    ConstValue b1 = ConstValue::CreateScalar(true);
-    ConstValue i0 = ConstValue::CreateScalar(0);
-    ConstValue i1 = ConstValue::CreateScalar(1);
-    ConstValue i2 = ConstValue::CreateScalar(2);
-    ConstValue i3 = ConstValue::CreateScalar(3);
-    ConstValue i4 = ConstValue::CreateScalar(4);
+    ConstValue b0    = ConstValue::CreateScalar(false);
+    ConstValue b1    = ConstValue::CreateScalar(true);
+    ConstValue i0    = ConstValue::CreateScalar(0);
+    ConstValue i1    = ConstValue::CreateScalar(1);
+    ConstValue i2    = ConstValue::CreateScalar(2);
+    ConstValue i3    = ConstValue::CreateScalar(3);
+    ConstValue i4    = ConstValue::CreateScalar(4);
     ConstValue f2_75 = ConstValue::CreateScalar(2.75f);
-    ConstValue f3 = ConstValue::CreateScalar(3.0f);
-    ConstValue f4 = ConstValue::CreateScalar(4.0f);
+    ConstValue f3    = ConstValue::CreateScalar(3.0f);
+    ConstValue f4    = ConstValue::CreateScalar(4.0f);
 
     ConstValue bv4_0101 = ConstValue::CreateVector<bool>({false, true, false, true});
     ConstValue bv4_0011 = ConstValue::CreateVector<bool>({false, false, true, true});
@@ -143,14 +143,12 @@ TEST_CASE("Compiler::ConstValueTest")
     ConstValue v4_0123  = ConstValue::CreateVector<float>({0.0f, 1.0f, 2.0f, 3.0f});
     ConstValue v4_1111  = ConstValue::CreateVector<float>({1.0f, 1.0f, 1.0f, 1.0f});
 
-    ConstValue im2x3_123456 = ConstValue::ConstructMatrix(ConstValue::CreateVector<int32_t>({1, 2, 3, 4, 5, 6}),
-                                                          ScalarKind::Int, 2, 3);
-    ConstValue m2x3_123456  = ConstValue::ConstructMatrix(ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f,
-                                                                                           5.0f, 6.0f}),
-                                                          ScalarKind::Float, 2, 3);
-    ConstValue m3x2_123456  = ConstValue::ConstructMatrix(ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f,
-                                                                                           5.0f, 6.0f}),
-                                                          ScalarKind::Float, 3, 2);
+    ConstValue im2x3_123456 =
+        ConstValue::ConstructMatrix(ConstValue::CreateVector<int32_t>({1, 2, 3, 4, 5, 6}), ScalarKind::Int, 2, 3);
+    ConstValue m2x3_123456 = ConstValue::ConstructMatrix(
+        ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}), ScalarKind::Float, 2, 3);
+    ConstValue m3x2_123456 = ConstValue::ConstructMatrix(
+        ConstValue::CreateVector<float>({1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}), ScalarKind::Float, 3, 2);
 
     SECTION("Unary Element-wise Arithmetics")
     {
@@ -578,8 +576,8 @@ TEST_CASE("Compiler::ConstValueTest")
             REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Bool), {false, true, true, true}));
             REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Float), {0.0f, 1.0f, 2.0f, 3.0f}));
             REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Double), {0.0, 1.0, 2.0, 3.0}));
-            REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Uint64), {uint64_t(0), uint64_t(1), uint64_t(2),
-                                                                              uint64_t(3)}));
+            REQUIRE(TestConstVector(iv4_0123.CastScalar(ScalarKind::Uint64),
+                                    {uint64_t(0), uint64_t(1), uint64_t(2), uint64_t(3)}));
 
             REQUIRE(TestConstVector(bv4_0101.CastScalar(ScalarKind::Int), {0, 1, 0, 1}));
         }
@@ -588,8 +586,8 @@ TEST_CASE("Compiler::ConstValueTest")
         {
             REQUIRE(TestConstMatrix(im2x3_123456.CastScalar(ScalarKind::Float), 2, 3,
                                     {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
-            REQUIRE(TestConstMatrix(im2x3_123456.CastScalar(ScalarKind::Bool), 2, 3,
-                                    {true, true, true, true, true, true}));
+            REQUIRE(
+                TestConstMatrix(im2x3_123456.CastScalar(ScalarKind::Bool), 2, 3, {true, true, true, true, true, true}));
         }
 
         SECTION("Error")

--- a/glsld-test/src/Server/ConfigTest.cpp
+++ b/glsld-test/src/Server/ConfigTest.cpp
@@ -1,6 +1,6 @@
-#include "Server/Config.h"
+#include "Catch2Wrapper.h"
 
-#include <catch2/catch_test_macros.hpp>
+#include "Server/Config.h"
 
 using namespace glsld;
 

--- a/glsld-test/src/Server/FoldingRangeTest.cpp
+++ b/glsld-test/src/Server/FoldingRangeTest.cpp
@@ -2,8 +2,6 @@
 
 #include "Feature/FoldingRange.h"
 
-#include <catch2/catch_test_macros.hpp>
-
 using namespace glsld;
 
 static auto MockFoldingRange(const ServerTestFixture& fixture, const FoldingRangeConfig& config = {.enable = true})

--- a/glsld-test/src/Server/InlayHintTest.cpp
+++ b/glsld-test/src/Server/InlayHintTest.cpp
@@ -4,8 +4,6 @@
 #include "Support/SourceText.h"
 #include "Support/StringView.h"
 
-#include <catch2/catch_test_macros.hpp>
-
 #include <algorithm>
 #include <optional>
 

--- a/glsld-test/src/Server/ProtocolTest.cpp
+++ b/glsld-test/src/Server/ProtocolTest.cpp
@@ -1,6 +1,6 @@
-#include "Server/Protocol.h"
+#include "Catch2Wrapper.h"
 
-#include <catch2/catch_test_macros.hpp>
+#include "Server/Protocol.h"
 
 using namespace glsld;
 

--- a/glsld-test/src/Support/ArraySpanTest.cpp
+++ b/glsld-test/src/Support/ArraySpanTest.cpp
@@ -1,6 +1,6 @@
-#include "Support/ArraySpan.h"
+#include "Catch2Wrapper.h"
 
-#include <catch2/catch_test_macros.hpp>
+#include "Support/ArraySpan.h"
 
 #include <array>
 #include <span>

--- a/glsld-test/src/Support/EnumReflectionTest.cpp
+++ b/glsld-test/src/Support/EnumReflectionTest.cpp
@@ -1,6 +1,7 @@
+#include "Catch2Wrapper.h"
+
 #include "Support/EnumReflection.h"
 
-#include <catch2/catch_test_macros.hpp>
 #include <iterator>
 #include <vector>
 

--- a/glsld-test/src/Support/JsonSerializerTest.cpp
+++ b/glsld-test/src/Support/JsonSerializerTest.cpp
@@ -1,6 +1,6 @@
-#include "Support/JsonSerializer.h"
+#include "Catch2Wrapper.h"
 
-#include <catch2/catch_test_macros.hpp>
+#include "Support/JsonSerializer.h"
 
 using namespace glsld;
 

--- a/glsld-test/src/Support/StringViewTest.cpp
+++ b/glsld-test/src/Support/StringViewTest.cpp
@@ -1,6 +1,6 @@
-#include "Support/StringView.h"
+#include "Catch2Wrapper.h"
 
-#include <catch2/catch_test_macros.hpp>
+#include "Support/StringView.h"
 
 #include <array>
 #include <string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test dependencies to use a centralized Catch2 wrapper header across test files.
  * Enhanced enum string representation in test assertions through generalized template support.

* **Chores**
  * Updated Catch2 testing dependency from v3.12.0 to v3.15.0 with improved string maker support for test output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daiyousei-qz/glsld/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->